### PR TITLE
Image dimensions are an issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ The dapp is automatically deployed for every change on the `staging` and `main` 
 
 - staging is the default development branch where features are being tested before being merged on main
 - main is the production branch
+
+### Running your development environment using docker
+
+```
+make up
+make in
+yard dev
+```
+
+Access via http://localhost:3000

--- a/src/components/custom/CardMedia.tsx
+++ b/src/components/custom/CardMedia.tsx
@@ -13,7 +13,7 @@ function CardMedia(props: any) {
     ? src.toString().substring(21)
     : src.toString().substring(8, src.toString().length - 15);
 
-  const newSrc = `https://d2wwrm96vfy3z4.cloudfront.net/image?height=400&width=400&url=https://ipfs.io/ipfs/${ipfsId}`;
+  const newSrc = `https://d2wwrm96vfy3z4.cloudfront.net/image?height=360&width=314&url=https://ipfs.io/ipfs/${ipfsId}`;
 
   return (
     <VStack
@@ -27,8 +27,6 @@ function CardMedia(props: any) {
       {...others}
     >
       <Image
-        h="360px"
-        w="full"
         src={inViewport ? newSrc || src : "/not-sure-if-loading_o_427193.webp"}
         roundedTop="2xl"
         objectFit="cover"

--- a/src/components/custom/CardMedia.tsx
+++ b/src/components/custom/CardMedia.tsx
@@ -7,7 +7,7 @@ import { useInViewport } from "react-in-viewport";
 function CardMedia(props: any) {
   const { children, src, ...others } = props;
   const myRef = useRef();
-  const { inViewport } = useInViewport(myRef, {}, {}, props);
+  const { enterCount } = useInViewport(myRef, {}, {}, props);
 
   const ipfsId = src.toString().includes("ipfs.io")
     ? src.toString().substring(21)
@@ -27,7 +27,9 @@ function CardMedia(props: any) {
       {...others}
     >
       <Image
-        src={inViewport ? newSrc || src : "/not-sure-if-loading_o_427193.webp"}
+        src={
+          enterCount > 0 ? newSrc || src : "/not-sure-if-loading_o_427193.webp"
+        }
         roundedTop="2xl"
         objectFit="cover"
         fallbackSrc="/not-sure-if-loading_o_427193.webp"


### PR DESCRIPTION
Different image dimensions are an issue when it comes to a consistent display.  Currently the cropping of images causes some valuable bits of e.g. text to be removed.

The image resizer was changed to not do cropping and instead display the full image & fill in with #ffffff where needed.

Small tweaks to the frontend to work better with this new way of resizing.  We might need a more elegant solution, e.g. masonry layout.