### PR TITLE
Some quick wins

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -60,4 +60,14 @@ MyApp.defaultProps = {
   emotionCache: clientSideEmotionCache,
 };
 
+if (typeof window !== "undefined") {
+  // Redirect the user to an https connection for production.  This should rather be done server side down the line...
+  if (
+    window.location.hostname === "memes.party" &&
+    window.location.protocol === "http:"
+  ) {
+    window.location.replace(`https://${window.location.hostname}`);
+  }
+}
+
 export default MyApp;


### PR DESCRIPTION
- move the logic that redirects http -> https (wasn't working on prod)
- only load paginated results, instead of the lengthy request that returns all results
- add mechanism to prevent multiple scroll loading events from firing

** testing / another pair of eyes needed